### PR TITLE
add golang and odin

### DIFF
--- a/lib/regex.vim
+++ b/lib/regex.vim
@@ -24,6 +24,8 @@ export var outline_include_before_exclude = {
   java: true,
   tex: false,
   markdown: true,
+  go: true,
+  odin: true,
 }
 
 # For filter()
@@ -34,7 +36,9 @@ export var outline_pattern_to_include = {
         \ '^\s*sign ' ],
   tex: ["^\\\\\\w*section"],
   markdown: ['^\s*#'],
-  java: ['^\s*class', '^\s*public', '^\s*private', '^\s*protected']
+  java: ['^\s*class', '^\s*public', '^\s*private', '^\s*protected'],
+  go: ['^func ', '^type '],
+  odin: ['\v^[a-zA-Z0-9]+ :: '],
 }
 
 export var outline_pattern_to_exclude = {


### PR DESCRIPTION
Adding regex rules for go and odin.
They are both pretty easy to do regex since they discourage doing any nesting like nesting methods into a classes.

This pl.ugin is very good since I work in a regulated environment so can't install other tools like ctags.

![golang-outline](https://github.com/user-attachments/assets/301ea6e3-105b-4c36-9a35-2916b3f4751e)
